### PR TITLE
Ios date formatter service

### DIFF
--- a/Say Their Names.xcodeproj/project.pbxproj
+++ b/Say Their Names.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		7A5BFA12248618C000BC265A /* XCUIApplication+SayTheirName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5BFA01248615C100BC265A /* XCUIApplication+SayTheirName.swift */; };
 		7A5BFA14248618CF00BC265A /* Say_Their_NamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3ED7562481CA000033FF79 /* Say_Their_NamesTests.swift */; };
 		7A5BFA172488315D00BC265A /* DonationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5BFA162488315D00BC265A /* DonationsView.swift */; };
+		7A5BFA192488821500BC265A /* DateFormatterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5BFA182488821500BC265A /* DateFormatterService.swift */; };
+		7A5BFA1B2488871C00BC265A /* DateFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5BFA1A2488871C00BC265A /* DateFormatterServiceTests.swift */; };
 		7C47A93524873F1200B8D3BE /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C47A93424873F1200B8D3BE /* HomeView.swift */; };
 		83E9CAD02484A504001D173A /* LaunchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E9CACF2484A504001D173A /* LaunchScreen.swift */; };
 		83E9CAD22484A514001D173A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83E9CAD12484A514001D173A /* LaunchScreen.xib */; };
@@ -127,6 +129,8 @@
 		7A5BFA0A248618B100BC265A /* SayTheirNamesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SayTheirNamesUITests.swift; sourceTree = "<group>"; };
 		7A5BFA0C248618B100BC265A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7A5BFA162488315D00BC265A /* DonationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationsView.swift; sourceTree = "<group>"; };
+		7A5BFA182488821500BC265A /* DateFormatterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateFormatterService.swift; path = DateFormatter/DateFormatterService.swift; sourceTree = "<group>"; };
+		7A5BFA1A2488871C00BC265A /* DateFormatterServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateFormatterServiceTests.swift; path = DateFormatterServiceTest/DateFormatterServiceTests.swift; sourceTree = "<group>"; };
 		7A7C6C9D07F911D0BA41942E /* Pods_Say_Their_NamesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Say_Their_NamesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C47A93424873F1200B8D3BE /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		83E9CACF2484A504001D173A /* LaunchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreen.swift; sourceTree = "<group>"; };
@@ -267,6 +271,7 @@
 				B386F9532482FB2E0037A38D /* ExtensionsTests */,
 				5B3ED7582481CA000033FF79 /* Info.plist */,
 				5B3ED7562481CA000033FF79 /* Say_Their_NamesTests.swift */,
+				7A5BFA1A2488871C00BC265A /* DateFormatterServiceTests.swift */,
 			);
 			path = "Say Their NamesTests";
 			sourceTree = "<group>";
@@ -574,6 +579,7 @@
 				A91B07CE24849D8400DB803C /* ServiceReferring.swift */,
 				9E7DBAE7248481DA00635A56 /* ImageDownloader */,
 				A91B07BE2484704200DB803C /* Navigator */,
+				7A5BFA182488821500BC265A /* DateFormatterService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -890,6 +896,7 @@
 				7A5BFA172488315D00BC265A /* DonationsView.swift in Sources */,
 				7433B64B2484BABA005140D4 /* PersonPhotoCell.swift in Sources */,
 				A91B07A324835CF700DB803C /* PetitionsController.swift in Sources */,
+				7A5BFA192488821500BC265A /* DateFormatterService.swift in Sources */,
 				A91B079E24835CF700DB803C /* PersonController.swift in Sources */,
 				A91B07C32484719C00DB803C /* Bundle+STN.swift in Sources */,
 				A91B07AE24835CF700DB803C /* PersonHeaderCell.swift in Sources */,
@@ -920,6 +927,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A5BFA1B2488871C00BC265A /* DateFormatterServiceTests.swift in Sources */,
 				B386F9552482FB540037A38D /* UIFontSTNTests.swift in Sources */,
 				83E9CAD72484A6A2001D173A /* LaunchScreenTests.swift in Sources */,
 				7A5BFA14248618CF00BC265A /* Say_Their_NamesTests.swift in Sources */,

--- a/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
+++ b/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
@@ -15,8 +15,6 @@ protocol DateFormatterType {
 extension DateFormatter: DateFormatterType { }
 
 class DateFormatterService {
-
-    static let shared = DateFormatterService()
     
     /// To keep thread safe, designate this queue for searching cached formatters.
     let dateFormattersQueue = DispatchQueue(label: "com.stn.date.formatter.queue")
@@ -42,10 +40,10 @@ class DateFormatterService {
 
     // MARK: - Date Of Birth
 
-    func formatDOBDate(_ date: Date) -> String {
-        let dateFormatter = cachedDateFormatter(withFormat: "y/MM/dd @ HH:mm")
+    func formatYearMonthDayDate(_ date: Date) -> String {
+        let dateFormatter = cachedDateFormatter(withFormat: "y/MM/dd")
         let formattedDate = dateFormatter.string(from: date)
-        return ("Date of birth: \(formattedDate)")
+        return ("Date: \(formattedDate)")
     }
     
     // MARK: - Hour minute

--- a/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
+++ b/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
@@ -38,7 +38,7 @@ class DateFormatterService {
         }
     }
 
-    // MARK: - Date Of Birth
+    // MARK: - Year month day
 
     func formatYearMonthDayDate(_ date: Date) -> String {
         let dateFormatter = cachedDateFormatter(withFormat: "y/MM/dd")

--- a/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
+++ b/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
@@ -1,0 +1,56 @@
+//
+//  STNDateFormatter.swift
+//  Say Their Names
+//
+//  Created by Hakeem King on 6/3/20.
+//  Copyright © 2020 Franck-Stephane Ndame Mpouli. All rights reserved.
+//
+
+import Foundation
+
+protocol DateFormatterType {
+    func string(from date: Date) -> String
+}
+
+extension DateFormatter: DateFormatterType { }
+
+class DateFormatterService {
+
+    // MARK: - Shared
+
+    static let shared = DateFormatterService()
+    
+    // MARK: - Queue
+    
+    let dateFormattersQueue = DispatchQueue(label: "com.stn.date.formatter.queue")
+
+    // MARK: - Cached Formatters
+
+    private var dateFormatters = [String : DateFormatterType]()
+
+    private func cachedDateFormatter(withFormat format: String) -> DateFormatterType {
+        return dateFormattersQueue.sync {
+            let key = format
+            if let cachedFormatter = dateFormatters[key] {
+                return cachedFormatter
+            }
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.dateFormat = format
+            
+            dateFormatters[key] = dateFormatter
+            
+            return dateFormatters[key]!
+        }
+    }
+
+    // MARK: - Date Of Birth
+
+    func formatDOBDate(_ date: Date) -> String {
+        let dateFormatter = cachedDateFormatter(withFormat: "y/MM/dd @ HH:mm")
+        let formattedDate = dateFormatter.string(from: date)
+        return ("Date of birth: \(formattedDate)")
+    }
+
+}

--- a/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
+++ b/Say Their Names/Source/Service/DateFormatter/DateFormatterService.swift
@@ -16,15 +16,10 @@ extension DateFormatter: DateFormatterType { }
 
 class DateFormatterService {
 
-    // MARK: - Shared
-
     static let shared = DateFormatterService()
     
-    // MARK: - Queue
-    
+    /// To keep thread safe, designate this queue for searching cached formatters.
     let dateFormattersQueue = DispatchQueue(label: "com.stn.date.formatter.queue")
-
-    // MARK: - Cached Formatters
 
     private var dateFormatters = [String : DateFormatterType]()
 
@@ -51,6 +46,13 @@ class DateFormatterService {
         let dateFormatter = cachedDateFormatter(withFormat: "y/MM/dd @ HH:mm")
         let formattedDate = dateFormatter.string(from: date)
         return ("Date of birth: \(formattedDate)")
+    }
+    
+    // MARK: - Hour minute
+    
+    func formatHourMinuteDate(_ date: Date) -> String {
+        let dateFormatter = cachedDateFormatter(withFormat: "HH:mm")
+        return dateFormatter.string(from: date)
     }
 
 }

--- a/Say Their Names/Source/Service/Service.swift
+++ b/Say Their Names/Source/Service/Service.swift
@@ -12,7 +12,7 @@ import UIKit
 final class Service {
     lazy private(set) var navigator = Navigator(service: self)
     lazy private(set) var image = ImageService()
-    lazy private(set) var dateFormatter = DateFormatterService.shared
+    lazy private(set) var dateFormatter = DateFormatterService()
         
     // MARK: - Init
     init() {

--- a/Say Their Names/Source/Service/Service.swift
+++ b/Say Their Names/Source/Service/Service.swift
@@ -12,6 +12,7 @@ import UIKit
 final class Service {
     lazy private(set) var navigator = Navigator(service: self)
     lazy private(set) var image = ImageService()
+    lazy private(set) var dateFormatter = DateFormatterService.shared
         
     // MARK: - Init
     init() {

--- a/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
+++ b/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
@@ -11,12 +11,20 @@ import XCTest
 
 class DateFormatterServiceTests: XCTestCase {
     
-    func testLaunchScreenCanLoadNib() {
+    func testDateOfBirthFormat() {
         let dob = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
 
         let formattedDate = DateFormatterService.shared.formatDOBDate(dob)
 
         XCTAssertEqual(formattedDate, "Date of birth: 2020/06/03 @ 04:11")
+    }
+    
+    func testHourMinuteFormate() {
+        let hourMin = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
+
+        let formattedDate = DateFormatterService.shared.formatHourMinuteDate(hourMin)
+
+        XCTAssertEqual(formattedDate, "04:11")
     }
 }
 

--- a/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
+++ b/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
@@ -11,18 +11,20 @@ import XCTest
 
 class DateFormatterServiceTests: XCTestCase {
     
+    let dateFormatterService = DateFormatterService()
+    
     func testDateOfBirthFormat() {
-        let dob = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
+        let dob = Date.dateFrom(year: 2020, month: 06, day: 03)!
 
-        let formattedDate = DateFormatterService.shared.formatDOBDate(dob)
+        let formattedDate = dateFormatterService.formatYearMonthDayDate(dob)
 
-        XCTAssertEqual(formattedDate, "Date of birth: 2020/06/03 @ 04:11")
+        XCTAssertEqual(formattedDate, "Date: 2020/06/03")
     }
     
     func testHourMinuteFormat() {
         let hourMin = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
 
-        let formattedDate = DateFormatterService.shared.formatHourMinuteDate(hourMin)
+        let formattedDate = dateFormatterService.formatHourMinuteDate(hourMin)
 
         XCTAssertEqual(formattedDate, "04:11")
     }

--- a/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
+++ b/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
@@ -19,7 +19,7 @@ class DateFormatterServiceTests: XCTestCase {
         XCTAssertEqual(formattedDate, "Date of birth: 2020/06/03 @ 04:11")
     }
     
-    func testHourMinuteFormate() {
+    func testHourMinuteFormat() {
         let hourMin = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
 
         let formattedDate = DateFormatterService.shared.formatHourMinuteDate(hourMin)

--- a/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
+++ b/Say Their NamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
@@ -1,0 +1,36 @@
+//
+//  DateFormatterServiceTests.swift
+//  Say Their NamesTests
+//
+//  Created by Hakeem King on 6/3/20.
+//  Copyright © 2020 Franck-Stephane Ndame Mpouli. All rights reserved.
+//
+
+import XCTest
+@testable import Say_Their_Names
+
+class DateFormatterServiceTests: XCTestCase {
+    
+    func testLaunchScreenCanLoadNib() {
+        let dob = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11)!
+
+        let formattedDate = DateFormatterService.shared.formatDOBDate(dob)
+
+        XCTAssertEqual(formattedDate, "Date of birth: 2020/06/03 @ 04:11")
+    }
+}
+
+extension Date {
+    static func dateFrom(year: Int, month: Int,  day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = second
+        components.timeZone = Calendar.current.timeZone
+
+        return Calendar.current.date(from: components)
+    }
+}


### PR DESCRIPTION
This PR is creating a date formatting service per this ticket : https://trello.com/c/CjE2733E

Currently this formatter supports a DOB format and a hour minute format. I am open to changing the formats or adding more, but I just wanted to begin with these two to get a service up and running. 

We use a singleton instance to avoid creating new instances across the app.