### PR TITLE
Removed warnings about TODOs and FIXMEs from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
     - closure_parameter_position
     - trailing_comma
     - duplicate_enum_cases
+    - todo
 
 opt_in_rules:
   - force_unwrapping


### PR DESCRIPTION
As requested in [Remove TODO and FIXME warnings from SwiftLint](https://trello.com/c/iqKTAhJZ) I have added "todo" in the list of disabled rules.

Before the fix :

![Screen Shot 2020-06-04 at 6 55 20 PM](https://user-images.githubusercontent.com/3268395/83822089-b8dc3a80-a695-11ea-8b8e-05ce174b7f98.png)
![Screen Shot 2020-06-04 at 6 55 42 PM](https://user-images.githubusercontent.com/3268395/83822094-ba0d6780-a695-11ea-955c-94d424175988.png)

After the fix : 

![Screen Shot 2020-06-04 at 6 56 49 PM](https://user-images.githubusercontent.com/3268395/83822119-cc87a100-a695-11ea-9b32-2b0fe598f179.png)
![Screen Shot 2020-06-04 at 6 56 57 PM](https://user-images.githubusercontent.com/3268395/83822122-cc87a100-a695-11ea-9234-123a97cae458.png)

✋👇
**Note :** while I understand the desire to clean up messages from the build logs, it's however problematic, imo, to leave todos and fixmes in the code without either warnings or corresponding issues. So I will go through the code and see if there are existing cards corresponding to those todos and if not, I will file some.