### PR TITLE
[FIX] Circular reference between Navigator & Service

### DIFF
--- a/SayTheirNames/Source/SceneDelegate.swift
+++ b/SayTheirNames/Source/SceneDelegate.swift
@@ -27,12 +27,12 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     
-    private let service = Service()
+    private let navigator = Navigator()
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        self.window = self.service.navigator.installSceneInWindow(windowScene)
+        self.window = navigator.installSceneInWindow(windowScene)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/SayTheirNames/Source/Service/Navigator/Navigator.swift
+++ b/SayTheirNames/Source/Service/Navigator/Navigator.swift
@@ -31,7 +31,7 @@ final class Navigator: ServiceReferring {
     
     // MARK: - Public methods
     
-    init(service: Servicing) {
+    init(service: Servicing = Service.shared) {
         self.service = service
         self.rootViewController = MainTabBarController(service: service)
         self.window = UIWindow()

--- a/SayTheirNames/Source/Service/Service.swift
+++ b/SayTheirNames/Source/Service/Service.swift
@@ -25,17 +25,17 @@
 import UIKit
 
 protocol Servicing {
-    var navigator: Navigator { get }
     var image: ImageService { get }
     var dateFormatter: DateFormatterService { get }
     var network: NetworkRequestor { get }
 }
 /// This is a core class that holds all instances responsible for logic
 final class Service: Servicing {
-    lazy private(set) var navigator = Navigator(service: self)
     lazy private(set) var image = ImageService()
     lazy private(set) var dateFormatter = DateFormatterService()
     lazy private(set) var network = NetworkRequestor()
+    
+    static let shared = Service()
     
     // MARK: - Init
     init() {


### PR DESCRIPTION
Fix circular reference between Navigator & Service 

Service stored a reference to Navigator which stored a reference to Service. This could lead to a retain cycle. 