### PR TITLE
[FIX] Localize dates

### DIFF
--- a/SayTheirNames/Source/Log/Log.swift
+++ b/SayTheirNames/Source/Log/Log.swift
@@ -24,8 +24,9 @@
 
 import UIKit
 
-// MARK: - Log
-public struct Log {
+// MARK: - Log namespace
+public enum Log {
+    
     public static var mode: Mode = .none
     
     public struct Mode: OptionSet {
@@ -53,14 +54,16 @@ public struct Log {
         Swift.print("\(prefix)\(stringItem)", terminator: terminator)
         #endif
     }
-    
+
+    private static let dateFormatterService = DateFormatterService()
+
     private static func _modePrefix(file: String, function: String, line: Int) -> String {
+        
         var result: String = ""
         
         if self.mode.contains(.date) {
-            let formatter = DateFormatterService()
-            let dateString = formatter.formatYearMonthDayAndTime(Date())
-            result += dateString
+            result += dateFormatterService.humanReadableTimestampString(from: Date())
+            result += " "
         }
         
         if self.mode.contains(.fileName) {

--- a/SayTheirNames/Source/View/Home/Person/PersonCell.swift
+++ b/SayTheirNames/Source/View/Home/Person/PersonCell.swift
@@ -26,12 +26,9 @@ import UIKit
 
 final class PersonCell: UICollectionViewCell {
     @DependencyInject private var dateFormatter: DateFormatterService
-
-    static let personIdentifier = "personCell"
     
     private lazy var profileImageView: UIImageView = {
         let imgV = UIImageView()
-        imgV.image = UIImage(asset: STNImage.manInRedJacket)
         imgV.contentMode = .scaleAspectFill
         imgV.clipsToBounds = true
         imgV.setContentHuggingPriority(.defaultLow, for: .vertical)
@@ -42,7 +39,6 @@ final class PersonCell: UICollectionViewCell {
     
     private lazy var nameLabel: UILabel = {
         let lbl = UILabel()
-        lbl.text = "GEORGE FLOYD"
         lbl.textColor = UIColor.STN.primaryLabel
         lbl.lineBreakMode = .byTruncatingTail
         lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -54,7 +50,6 @@ final class PersonCell: UICollectionViewCell {
     
     private lazy var dateOfIncidentLabel: UILabel = {
         let lbl = UILabel()
-        lbl.text = "25.05.2020"
         lbl.textColor = UIColor.STN.secondaryLabel
         lbl.lineBreakMode = .byTruncatingTail
         lbl.isAccessibilityElement = true
@@ -106,7 +101,7 @@ final class PersonCell: UICollectionViewCell {
     func configure(with person: Person) {
         profileImageView.populate(withURL: person.images.first?.personURL ?? "")
         nameLabel.text = person.fullName.uppercased()
-        dateOfIncidentLabel.text = self.dateFormatter.formatYearMonthDayDate(person.doi)
+        dateOfIncidentLabel.text = self.dateFormatter.dateOfIncidentString(from: person.doi)
     }
     
     private func setUp() {

--- a/SayTheirNamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
+++ b/SayTheirNamesTests/DateFormatterServiceTest/DateFormatterServiceTests.swift
@@ -27,33 +27,29 @@ import XCTest
 
 class DateFormatterServiceTests: XCTestCase {
     
-    let dateFormatterService = DateFormatterService()
-    
-    func testDateOfBirthFormat() {
-        guard let dob = Date.dateFrom(year: 2020, month: 06, day: 03) else {
-            XCTFail("unable to create dob")
-            return
-        }
-
-        let formattedDate = dateFormatterService.formatYearMonthDayDate(dob)
-
-        XCTAssertEqual(formattedDate, "2020/06/03")
-    }
-    
-    func testHourMinuteFormat() {
-        guard let hourMin = Date.dateFrom(year: 2020, month: 06, day: 03, hour: 4, minute: 11) else {
+    func testDateOfIncidentFormatter() {
+        guard let date = Date.dateFrom(year: 2020, month: 06, day: 03) else {
             XCTFail("unable to create date")
             return
         }
-
-        let formattedDate = dateFormatterService.formatHourMinuteDate(hourMin)
-
-        XCTAssertEqual(formattedDate, "04:11")
+        let dateFormatterService = DateFormatterService(localeProvider: { Locale(identifier: "en_US") })
+        let formattedDate = dateFormatterService.dateOfIncidentString(from: date)
+        XCTAssertEqual(formattedDate, "6/3/20", "The date should be formatted according to US date format")
+    }
+    
+    func testDateOfIncidentFormatterRespectsLocale() {
+        guard let date = Date.dateFrom(year: 2020, month: 06, day: 03) else {
+            XCTFail("unable to create date")
+            return
+        }
+        let dateFormatterService = DateFormatterService(localeProvider: { Locale(identifier: "en_DK") })
+        let formattedDate = dateFormatterService.dateOfIncidentString(from: date)
+        XCTAssertEqual(formattedDate, "03/06/2020", "The date should be formatted according to DK date format")
     }
 }
 
 extension Date {
-    static func dateFrom(year: Int, month: Int,  day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) -> Date? {
+    fileprivate static func dateFrom(year: Int, month: Int,  day: Int, hour: Int = 0, minute: Int = 0, second: Int = 0) -> Date? {
         var components = DateComponents()
         components.year = year
         components.month = month


### PR DESCRIPTION
revamp of #76 

- Date follows date format set on device
- Caching formatters by purpose to achieve consistent formatting across the app. Caching by date format is not applicable since that is different for different locales. 