### PR TITLE
Fix missing launch asset in launch screen

### DIFF
--- a/SayTheirNames/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/SayTheirNames/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -15,7 +15,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="STN-Logo-white" translatesAutoresizingMaskIntoConstraints="NO" id="DOV-dJ-IuG">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="STN_logo_white" translatesAutoresizingMaskIntoConstraints="NO" id="DOV-dJ-IuG">
                                 <rect key="frame" x="144.5" y="385.5" width="125" height="125"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="125" id="rAp-d5-TF9"/>
@@ -37,6 +37,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="STN-Logo-white" width="1032" height="1459"/>
+        <image name="STN_logo_white" width="1032.5" height="1459"/>
     </resources>
 </document>

--- a/SayTheirNames/Source/Controller/Launch/LaunchScreen.xib
+++ b/SayTheirNames/Source/Controller/Launch/LaunchScreen.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -13,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="STN-Logo-white" translatesAutoresizingMaskIntoConstraints="NO" id="8TT-e6-qyq">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="STN_logo_white" translatesAutoresizingMaskIntoConstraints="NO" id="8TT-e6-qyq">
                     <rect key="frame" x="144.5" y="385.5" width="125" height="125"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="125" id="JSr-Ut-Onp"/>
@@ -34,6 +34,6 @@
         </view>
     </objects>
     <resources>
-        <image name="STN-Logo-white" width="1032" height="1459"/>
+        <image name="STN_logo_white" width="1032.5" height="1459"/>
     </resources>
 </document>

--- a/SayTheirNames/Source/View/HashtagView.swift
+++ b/SayTheirNames/Source/View/HashtagView.swift
@@ -35,7 +35,12 @@ class HashtagView: UIView {
     private func configureView() {
         layer.borderWidth = 1.5
         layer.borderColor = UIColor(asset: STNAsset.Color.primaryLabel).cgColor
-        hashtagLabel.anchor(superView: self, top: topAnchor, leading: leadingAnchor, bottom: bottomAnchor, trailing: trailingAnchor, padding: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), size: .zero)
+        hashtagLabel.anchor(superView: self,
+                            top: topAnchor,
+                            leading: leadingAnchor,
+                            bottom: bottomAnchor,
+                            trailing: trailingAnchor,
+                            padding: UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5), size: .zero)
     }
     private func updateCGColors() {
         layer.borderColor = UIColor(asset: STNAsset.Color.primaryLabel).cgColor


### PR DESCRIPTION
Asset was renamed in #142 so this PR fixes that (as well as a swiftlint warning)