### PR TITLE
[CHORE] fixed PersonCell layout breaking when image size changes

### DIFF
--- a/SayTheirNames/Source/View/Home/Person/PersonCell.swift
+++ b/SayTheirNames/Source/View/Home/Person/PersonCell.swift
@@ -108,6 +108,9 @@ final class PersonCell: UICollectionViewCell {
         labelsAndButtonContainer.addSubview(nameLabel)
         labelsAndButtonContainer.addSubview(dateOfIncidentLabel)
         labelsAndButtonContainer.addSubview(bookmarkButton)
+
+        containerStack.addArrangedSubview(profileImageView)
+        containerStack.addArrangedSubview(labelsAndButtonContainer)
         NSLayoutConstraint.activate([
             nameLabel.topAnchor.constraint(equalTo: labelsAndButtonContainer.topAnchor),
             nameLabel.leadingAnchor.constraint(equalTo: labelsAndButtonContainer.leadingAnchor),
@@ -119,7 +122,9 @@ final class PersonCell: UICollectionViewCell {
             dateOfIncidentLabel.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor),
 
             bookmarkButton.topAnchor.constraint(equalTo: nameLabel.topAnchor),
-            bookmarkButton.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor)
+            bookmarkButton.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor),
+
+            profileImageView.heightAnchor.constraint(equalTo: containerStack.heightAnchor, multiplier: 0.8)
         ])
         
         containerStack.addArrangedSubview(profileImageView)


### PR DESCRIPTION
- added a height anchor constraint with an 80% multiplier

Task:- https://trello.com/c/3tvebl9J/110-personcell-layout-breaks-due-to-image-sizing

Before 

![Simulator Screen Shot - iPhone 11 - 2020-06-10 at 02 10 33](https://user-images.githubusercontent.com/9130129/84212969-b4fa4f00-aabf-11ea-9a90-1aef48597c66.png)

After

![Simulator Screen Shot - iPhone 11 - 2020-06-10 at 02 11 57](https://user-images.githubusercontent.com/9130129/84213019-d9562b80-aabf-11ea-9ecf-2f9baa2903f8.png)
