### PR TITLE
[CHORE]  Unit Tests for the Deep Linking mechanism.

### DIFF
--- a/SayTheirNames.xcodeproj/project.pbxproj
+++ b/SayTheirNames.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		8E1ECBF024908EC2009E6E44 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1ECBEF24908EC2009E6E44 /* DeepLinkTests.swift */; };
 		8E4155A42490605800333D76 /* JSONDataModelAPIs.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E4155A32490605800333D76 /* JSONDataModelAPIs.xcassets */; };
 		8E4155A6249076CA00333D76 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4155A5249076CA00333D76 /* ModelTests.swift */; };
+		8E5608142491C62400FF94C1 /* DeepLinkSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2830E24903042004283ED /* DeepLinkSupport.swift */; };
 		9E24499D2485E98C00B149DF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9E24499B2485E98C00B149DF /* Localizable.strings */; };
 		9E2449A02485EA0B00B149DF /* strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E24499F2485EA0B00B149DF /* strings.swift */; };
 		9E2449A32485EA7600B149DF /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2449A22485EA7600B149DF /* Typealiases.swift */; };
@@ -1466,6 +1467,7 @@
 				B365F45C248FD6340007FC31 /* PaginatorTests.swift in Sources */,
 				7CAD53EA248A32FC001CFF08 /* PeopleNetworkRequestorTests.swift in Sources */,
 				8E4155A6249076CA00333D76 /* ModelTests.swift in Sources */,
+				8E5608142491C62400FF94C1 /* DeepLinkSupport.swift in Sources */,
 				7CAD53E6248A2AEE001CFF08 /* DonationsNetworkRequestorTests.swift in Sources */,
 				7CAD53E3248A2A9F001CFF08 /* NetworkRequestorTests.swift in Sources */,
 				7CAD53E8248A326F001CFF08 /* PetitionsNetworkRequestorTests.swift in Sources */,

--- a/SayTheirNames.xcodeproj/project.pbxproj
+++ b/SayTheirNames.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		83E9CAD22484A514001D173A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83E9CAD12484A514001D173A /* LaunchScreen.xib */; };
 		83E9CAD42484A5DC001D173A /* UIViewController+TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E9CAD32484A5DC001D173A /* UIViewController+TabBar.swift */; };
 		83E9CAD72484A6A2001D173A /* LaunchScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E9CAD62484A6A2001D173A /* LaunchScreenTests.swift */; };
+		8E1ECBF024908EC2009E6E44 /* DeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1ECBEF24908EC2009E6E44 /* DeepLinkTests.swift */; };
 		8E4155A42490605800333D76 /* JSONDataModelAPIs.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E4155A32490605800333D76 /* JSONDataModelAPIs.xcassets */; };
 		8E4155A6249076CA00333D76 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4155A5249076CA00333D76 /* ModelTests.swift */; };
 		9E24499D2485E98C00B149DF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9E24499B2485E98C00B149DF /* Localizable.strings */; };
@@ -255,6 +256,7 @@
 		83E9CAD62484A6A2001D173A /* LaunchScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenTests.swift; sourceTree = "<group>"; };
 		846B629F2487CCFF00C0D1D5 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "ru-RU.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		846B62A02487CD1900C0D1D5 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "ru-RU.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		8E1ECBEF24908EC2009E6E44 /* DeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkTests.swift; sourceTree = "<group>"; };
 		8E4155A32490605800333D76 /* JSONDataModelAPIs.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = JSONDataModelAPIs.xcassets; sourceTree = "<group>"; };
 		8E4155A5249076CA00333D76 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		8E94BA59248A0A4100242FBA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 		7CAD53DF248A2A71001CFF08 /* ServiceTests */ = {
 			isa = PBXGroup;
 			children = (
+				8E1ECBEF24908EC2009E6E44 /* DeepLinkTests.swift */,
 				7CAD53E2248A2A9F001CFF08 /* NetworkRequestorTests.swift */,
 				7CAD53E4248A2AD8001CFF08 /* Requestors */,
 			);
@@ -1459,6 +1462,7 @@
 				B386F9552482FB540037A38D /* UIFontSTNTests.swift in Sources */,
 				7C166DC0248BB0310017A25A /* SearchNetworkRequestorTests.swift in Sources */,
 				5F62B732248975CF00ACE032 /* LocationCollectionViewDataSourceTests.swift in Sources */,
+				8E1ECBF024908EC2009E6E44 /* DeepLinkTests.swift in Sources */,
 				B365F45C248FD6340007FC31 /* PaginatorTests.swift in Sources */,
 				7CAD53EA248A32FC001CFF08 /* PeopleNetworkRequestorTests.swift in Sources */,
 				8E4155A6249076CA00333D76 /* ModelTests.swift in Sources */,

--- a/SayTheirNames/Source/Dependency/Deep Linking/DeepLinkHandler.swift
+++ b/SayTheirNames/Source/Dependency/Deep Linking/DeepLinkHandler.swift
@@ -36,25 +36,36 @@ final class DeepLinkHandler: Dependency {
     // MARK: - Public
     
     public func handle(urlContext: Set<UIOpenURLContext>) {
-        for context in urlContext {
-             if let deepLink = self.deepLink(matching: context) {
+        self.handle(urls: Set(urlContext.map { $0.url }))
+    }
+    
+    // We use this method as an entry point for unit tests.
+    // So we technically don't care about the resulting `DeepLink` array
+    // except for the unit tests.
+    @discardableResult
+    public func handle(urls: Set<URL>) -> [DeepLink] {
+        
+        var response: [DeepLink] = []
+        for url in urls {
+             if let deepLink = self.deepLink(matching: url) {
                 self.navigator.handle(deepLink: deepLink)
-                return
+                response.append(deepLink)
             }
         }
+        return response
     }
     
     // MARK: - Private
     
-    private func deepLink(matching context: UIOpenURLContext) -> DeepLink? {
-        guard let scheme = context.url.scheme, let host = context.url.host
+    private func deepLink(matching url: URL) -> DeepLink? {
+        guard let scheme = url.scheme, let host = url.host
         else { return nil }
         
         for deepLinkType in self.deepLinkTypes {
             let details = deepLinkType.details
             
             if details.uses(scheme: scheme, host: host) {
-                var components = context.url.pathComponents.filter { $0 != "/" }
+                var components = url.pathComponents.filter { $0 != "/" }
 
                 // We are navigating to home
                 if components.count == 0 {

--- a/SayTheirNamesTests/ServiceTests/DeepLinkTests.swift
+++ b/SayTheirNamesTests/ServiceTests/DeepLinkTests.swift
@@ -40,16 +40,16 @@ class DeepLinkTests: XCTestCase {
     var dlDonationFloydG: URL!
     
     // The scheme and host that should be used.
-    let dlScheme = "stn"
-    let dlHost = "saytheirname.netlify.app"
+    let dlScheme = DeepLinkSupport.Schema.stn
+    let dlHost = DeepLinkSupport.Host.default
     
     // The relative paths for deep link URLs
-    let dlPathAbout = "about"
-    let dlPathPeopleJaoP = "profile/joao-pedro"
-    let dlPathPetitions = "petitions"
-    let dlPathDonations = "donations"
-    let dlPathPetitionScurlock = "petitions/petition-for-james-scurlock"
-    let dlPathDonationFloydG = "donate/donate-to-george-floyd"
+    let dlPathAbout = DeepLinkSupport.Path.about
+    let dlPathPeopleJaoP = DeepLinkSupport.Path.profile + "/joao-pedro"
+    let dlPathPetitions = DeepLinkSupport.Path.petitions
+    let dlPathDonations = DeepLinkSupport.Path.donations
+    let dlPathPetitionScurlock = DeepLinkSupport.Path.sign + "/petition-for-james-scurlock"
+    let dlPathDonationFloydG = DeepLinkSupport.Path.donate + "/donate-to-george-floyd"
     
     var container: DependencyContainer!
 
@@ -76,7 +76,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                                  controller: MoreController.self,
                                  deeplinkDescription: "The About",
-                                 location: dlPathAbout)
+                                 location: DeepLinkSupport.Path.about)
     }
     
     /// Testing the People Detail deep link.
@@ -87,7 +87,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                                  controller: HomeController.self,
                                  deeplinkDescription: "The People Detail",
-                                 location: dlPathPeopleJaoP)
+                                 location: DeepLinkSupport.Path.profile)
 
     }
     
@@ -98,7 +98,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                                  controller: PetitionsController.self,
                                  deeplinkDescription: "The Petitions",
-                                 location: dlPathPetitions)
+                                 location: DeepLinkSupport.Path.petitions)
     }
 
     /// Testing the Donations deep link.
@@ -108,7 +108,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                                  controller: DonationsController.self,
                                  deeplinkDescription: "The Donations",
-                                 location: dlPathDonations)
+                                 location: DeepLinkSupport.Path.donations)
     }
     
     /// Testing the Petitions Detail deep link.
@@ -119,7 +119,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                              controller: PetitionsController.self,
                              deeplinkDescription: "The Petition Detail",
-                             location: dlPathPetitionScurlock)
+                             location: DeepLinkSupport.Path.sign)
     }
     
     /// Testing the Donation Detail deep link.
@@ -130,7 +130,7 @@ class DeepLinkTests: XCTestCase {
         self.helperAssertion(deeplinks: results,
                              controller: DonationsController.self,
                              deeplinkDescription: "The Donation Detail",
-                             location: dlPathDonationFloydG)
+                             location: DeepLinkSupport.Path.donate)
     }
 
     /// Helper method that will test the following assertions based
@@ -153,7 +153,7 @@ class DeepLinkTests: XCTestCase {
                           deeplinkDescription + " DeepLink should be shown in the \(controller.description())")
             XCTAssertTrue(details.uses(scheme: dlScheme, host: dlHost),
                           "The scheme or host is incorrect")
-            XCTAssertTrue(details.has(location: location.components(separatedBy: "/").first ?? location),
+            XCTAssertTrue(details.has(location: location),
                           "The path component is incorrect")
         }
 

--- a/SayTheirNamesTests/ServiceTests/DeepLinkTests.swift
+++ b/SayTheirNamesTests/ServiceTests/DeepLinkTests.swift
@@ -1,0 +1,161 @@
+//
+//  DeepLinkTests.swift
+//  SayTheirNames
+//
+//  Copyright (c) 2020 Say Their Names Team (https://github.com/Say-Their-Name)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+@testable import Say_Their_Names
+
+/// Unit Tests for the Deep Linking mechanism.
+/// The test cases rely on properly building a set of `DeepLink`s
+/// from the DeepLinkHandler's `handle(urls:)` method.
+///
+class DeepLinkTests: XCTestCase {
+
+    // The URLs that will be used to construct the deep links.
+    var dlAbout: URL!
+    var dlPeopleJaoP: URL!
+    var dlPetitions: URL!
+    var dlDonations: URL!
+    var dlPetitionScurlock: URL!
+    var dlDonationFloydG: URL!
+    
+    // The scheme and host that should be used.
+    let dlScheme = "stn"
+    let dlHost = "saytheirname.netlify.app"
+    
+    // The relative paths for deep link URLs
+    let dlPathAbout = "about"
+    let dlPathPeopleJaoP = "profile/joao-pedro"
+    let dlPathPetitions = "petitions"
+    let dlPathDonations = "donations"
+    let dlPathPetitionScurlock = "petitions/petition-for-james-scurlock"
+    let dlPathDonationFloydG = "donate/donate-to-george-floyd"
+    
+    var container: DependencyContainer!
+
+    override func setUpWithError() throws {
+
+        // We setup all the deep link URLs. An exception is thrown is the URL
+        // can't be built from the given string.
+        dlAbout = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathAbout))
+        dlPeopleJaoP = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathPeopleJaoP))
+        dlPetitions = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathPetitions))
+        dlDonations = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathDonations))
+        dlPetitionScurlock = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathPetitionScurlock))
+        dlDonationFloydG = try XCTUnwrap(URL(string: dlScheme + "://" + dlHost + "/" + dlPathDonationFloydG))
+
+        // We instantiate the dependency container that will be used to build
+        // the various `DeepLink` objects, via `.deepLinkHandler.handle(urls:)`
+        container = DependencyContainer()
+    }
+
+    /// Testing the About deep link.
+    func testAboutDeepLink() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlAbout]))
+        
+        self.helperAssertion(deeplinks: results,
+                                 controller: MoreController.self,
+                                 deeplinkDescription: "The About",
+                                 location: dlPathAbout)
+    }
+    
+    /// Testing the People Detail deep link.
+    /// This is a link to a specific person's profile.
+    func testPeopleJaoPDeepLink() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlPeopleJaoP]))
+        
+        self.helperAssertion(deeplinks: results,
+                                 controller: HomeController.self,
+                                 deeplinkDescription: "The People Detail",
+                                 location: dlPathPeopleJaoP)
+
+    }
+    
+    /// Testing the Petitions deep link.
+    func testPetitionsDeepLink() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlPetitions]))
+        
+        self.helperAssertion(deeplinks: results,
+                                 controller: PetitionsController.self,
+                                 deeplinkDescription: "The Petitions",
+                                 location: dlPathPetitions)
+    }
+
+    /// Testing the Donations deep link.
+    func testDonationsDeepLink() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlDonations]))
+        
+        self.helperAssertion(deeplinks: results,
+                                 controller: DonationsController.self,
+                                 deeplinkDescription: "The Donations",
+                                 location: dlPathDonations)
+    }
+    
+    /// Testing the Petitions Detail deep link.
+    /// This is a link to a specific petition page.
+    func testPetitionScurlockDeepLink() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlPetitionScurlock]))
+        
+        self.helperAssertion(deeplinks: results,
+                             controller: PetitionsController.self,
+                             deeplinkDescription: "The Petition Detail",
+                             location: dlPathPetitionScurlock)
+    }
+    
+    /// Testing the Donation Detail deep link.
+    /// This is a link to a specific donation page.
+    func testDonationFloydG() {
+        let results = container.deepLinkHandler.handle(urls: Set([dlDonationFloydG]))
+        
+        self.helperAssertion(deeplinks: results,
+                             controller: DonationsController.self,
+                             deeplinkDescription: "The Donation Detail",
+                             location: dlPathDonationFloydG)
+    }
+
+    /// Helper method that will test the following assertions based
+    /// on the provided `DeepLink` array :
+    ///   - there should only be one DeepLink for this test case.
+    ///   - the DeepLink has the appropriate display class (view controller)
+    ///   - the DeepLink has the correct scheme and host
+    ///   - the DeepLink has the correct path location (first part of the path components)
+    ///
+    func helperAssertion(deeplinks: [DeepLink],
+                         controller: UIViewController.Type,
+                         deeplinkDescription: String,
+                         location: String) {
+        
+        XCTAssertTrue(deeplinks.count == 1, "There should be only one (deep link).")
+        
+        for deeplink in deeplinks  {
+            let details = type(of: deeplink).details
+            XCTAssertTrue(details.canDisplayClass(controller.self),
+                          deeplinkDescription + " DeepLink should be shown in the \(controller.description())")
+            XCTAssertTrue(details.uses(scheme: dlScheme, host: dlHost),
+                          "The scheme or host is incorrect")
+            XCTAssertTrue(details.has(location: location.components(separatedBy: "/").first ?? location),
+                          "The path component is incorrect")
+        }
+
+    }
+}


### PR DESCRIPTION
The test cases rely on properly building a set of `DeepLink`s from the `DeepLinkHandler`'s `handle(urls:)` method.
Assertions will validate that :
   - there should only be one `DeepLink` per test case.
   - the `DeepLink` has the appropriate display class (view controller)
   - the `DeepLink` has the correct scheme and host
   - the `DeepLink` has the correct path location (first part of the path components)

Note that we had to slightly modify the `handle(urlContext:)` method of the `DeepLinkHandler` class (inserting a new intermediary method) to be able to set deep link URLs from the unit tests.

![Screen Shot 2020-06-10 at 5 57 13 PM](https://user-images.githubusercontent.com/3268395/84327411-dcdfc600-ab44-11ea-822d-e19a9966e0e1.png)

![Screen Shot 2020-06-10 at 5 57 25 PM](https://user-images.githubusercontent.com/3268395/84327413-dd785c80-ab44-11ea-8f0c-d4f695f24eb0.png)
