### PR TITLE
Make hashtags copyable

### DIFF
--- a/SayTheirNames/Resources/Base.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/Base.lproj/Localizable.strings
@@ -33,6 +33,7 @@
 "person.news" = "News";
 "person.media" = "Media";
 "person.hashtags" = "Social Media Hashtags";
+"person.hashtagCopyTip" = "Press and hold to copy";
 "get_involved_dev.title" = "HOW DO I GET INVOLVED AS A DEVELOPER?";
 "get_involved_design.title" = "HOW DO I GET INVOLVED AS A DESIGNER?";
 "view_repo" = "VIEW OUR REPO";

--- a/SayTheirNames/Resources/Generated/strings.swift
+++ b/SayTheirNames/Resources/Generated/strings.swift
@@ -83,6 +83,8 @@ internal enum L10n {
     internal static let children = L10n.tr("Localizable", "person.children")
     /// Social Media Hashtags
     internal static let hashtags = L10n.tr("Localizable", "person.hashtags")
+    /// Press and hold to copy
+    internal static let hashtagCopyTip = L10n.tr("Localizable", "person.hashtagCopyTip")
     /// Location
     internal static let location = L10n.tr("Localizable", "person.location")
     /// Media

--- a/SayTheirNames/Source/View/Hashtag/HashtagTableViewCell.swift
+++ b/SayTheirNames/Source/View/Hashtag/HashtagTableViewCell.swift
@@ -47,6 +47,17 @@ class HashtagTableViewCell: UITableViewCell {
         return label
     }()
     
+    lazy var hashtagCopyTipLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Person.hashtagCopyTip.localizedUppercase
+        label.textColor = UIColor(asset: STNAsset.Color.strongHeader)
+        label.font = UIFont.STN.bannerSubitle
+        label.numberOfLines = 1
+        label.minimumScaleFactor = 0.5
+        label.adjustsFontSizeToFitWidth = true
+        return label
+    }()
+    
     lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -111,8 +122,15 @@ class HashtagTableViewCell: UITableViewCell {
                             trailing: trailingAnchor,
                             padding: .init(top: Theme.Components.Padding.big, left: Theme.Components.Padding.large))
 
+        hashtagCopyTipLabel.anchor(superView: self,
+                                   top: hashtagLabel.bottomAnchor,
+                                   leading: leadingAnchor,
+                                   trailing: trailingAnchor,
+                                   padding: .init(left: Theme.Components.Padding.large),
+                                   size: CGSize(width: 0, height: 20))
+        
         collectionView.anchor(superView: self,
-                              top: hashtagLabel.bottomAnchor,
+                              top: hashtagCopyTipLabel.bottomAnchor,
                               leading: leadingAnchor,
                               trailing: trailingAnchor,
                               padding: .init(top: Theme.Components.Padding.medium),

--- a/SayTheirNames/Source/View/Hashtag/HashtagView.swift
+++ b/SayTheirNames/Source/View/Hashtag/HashtagView.swift
@@ -39,10 +39,13 @@ class HashtagView: UIView {
         return label
     }()
 
+    private var originalText: String!
+    
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: .zero)
         configureView()
+        setupLongPressGestureRecognizer()
     }
     
     required init?(coder: NSCoder) {
@@ -67,6 +70,35 @@ class HashtagView: UIView {
     
     private func updateCGColors() {
         layer.borderColor = UIColor(asset: STNAsset.Color.primaryLabel).cgColor
+    }
+    
+    private func setupLongPressGestureRecognizer() {
+        addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(copyHashtagToClipboard)))
+    }
+    
+    @objc private func copyHashtagToClipboard(gestureRecognizer: UIGestureRecognizer) {
+        
+        if gestureRecognizer.state == UIGestureRecognizer.State.began {
+            print("Copying \(hashtagLabel.text ?? "") to clipboard")
+            let pasteBoard = UIPasteboard.general
+            if let text = hashtagLabel.text {
+                originalText = text
+                pasteBoard.string = originalText
+                UIView.animate(withDuration: 0.5) {
+                    self.hashtagLabel.text = "Copied"
+                    //Swapping the text and background color so indicate something has changed
+                    self.backgroundColor = UIColor(asset: STNAsset.Color.strongHeader)
+                    self.hashtagLabel.textColor = UIColor(asset: STNAsset.Color.background)
+                }
+            }
+        } else if gestureRecognizer.state == UIGestureRecognizer.State.ended {
+            UIView.animate(withDuration: 0.5) {
+                self.hashtagLabel.text = self.originalText
+                self.backgroundColor = .clear
+                self.hashtagLabel.textColor = UIColor(asset: STNAsset.Color.strongHeader)
+            }
+        }
+        
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
Made the Hashtag in HashtagView copyable for easier sharing. Added a label informing the user that they can tap and hold a hashtag to copy it to the clipboard. Temporarily changes the text in the hashtagLabel to say "copied" and inverts the colors to make it clear something happened (in case the text is hidden under the user's finger).

Included a gif of the feature in action, and it even works in dark mode!
![HashtagCopy](https://user-images.githubusercontent.com/39202767/84393343-22af9380-ac04-11ea-9c90-419e57a9732c.gif)
