### PR TITLE
[BUG] Hide loading spinner after media fails to load

### DIFF
--- a/SayTheirNames/Source/Controller/Home/Person/Views/PersonNewsCollectionViewCell.swift
+++ b/SayTheirNames/Source/Controller/Home/Person/Views/PersonNewsCollectionViewCell.swift
@@ -73,6 +73,9 @@ class PersonNewsCollectionViewCell: UICollectionViewCell {
                         }
                     case .failure(let error):
                         print(url)
+                        DispatchQueue.main.async {
+                            self?.loadingIndicator.stopAnimating()
+                        }
                         Log.print(error.localizedDescription)
                     }
                 }


### PR DESCRIPTION
Set the loading spinner to hide if media fails to download. 