### PR TITLE
[CHORE] Fixed Nav and Tab Bar Title Size

### DIFF
--- a/SayTheirNames/Source/Utils/Fonts/UIFont+Resource.swift
+++ b/SayTheirNames/Source/Utils/Fonts/UIFont+Resource.swift
@@ -85,14 +85,14 @@ extension UIFont {
             textStyle: .body) }
 
         // 21 on figma but this yields 22 on default
-        static var navBarTitle: UIFont { UIFont.dynamicCustomFont(
+        static var navBarTitle: UIFont { UIFont.fixedCustomFont(
             fontName: FontName.karlaRegular.rawValue,
-            textStyle: .title2) }
+            size: 22) }
         
         // 13
-        static var tabButtonTitle: UIFont { UIFont.dynamicCustomFont(
-            fontName: FontName.karlaBold.rawValue,
-            textStyle: .footnote) }
+        static var tabButtonTitle: UIFont { UIFont.fixedCustomFont(
+                fontName: FontName.karlaBold.rawValue,
+                size: 13) }
         
         static var verifiedTag: UIFont { UIFont.dynamicCustomFont(fontName: FontName.karlaBold.rawValue, textStyle: .footnote) }
 


### PR DESCRIPTION
### Info 
- HIG states that the nav and tab bar should be clearly visible at all times
  - https://developer.apple.com/design/human-interface-guidelines/ios/bars/tab-bars/
  - https://developer.apple.com/design/human-interface-guidelines/ios/bars/navigation-bars/

### Before
<img width="300" alt="before" src="https://user-images.githubusercontent.com/170644/84463675-fdea0900-ac61-11ea-9524-229820ebbf0d.png">

### After
<img width="300" alt="after" src="https://user-images.githubusercontent.com/170644/84463710-1e19c800-ac62-11ea-8ae3-61ce06679396.png">
