### PR TITLE
[CHORE] Change print to Log.print

### DIFF
--- a/SayTheirNames/Source/Controller/Donations/DonationsController.swift
+++ b/SayTheirNames/Source/Controller/Donations/DonationsController.swift
@@ -103,7 +103,7 @@ final class DonationsController: UIViewController {
             return cell
         }
         filterManager.didSelectItem = { filter in
-            print(filter)
+            Log.print(filter)
         }
         ui.bindFilterManager(filterManager)
     }

--- a/SayTheirNames/Source/Controller/Home/CollectionViewDataSource/Carousel/LineCarouselControl.swift
+++ b/SayTheirNames/Source/Controller/Home/CollectionViewDataSource/Carousel/LineCarouselControl.swift
@@ -55,7 +55,7 @@ final class LineCarouselControl: UIControl {
     var numberOfPages: Int = 0 {
         didSet(oldValue) {
             for tag in 0 ..< numberOfPages {
-                print(tag)
+                Log.print(tag)
                 let line = getLineView()
                 line.tag = tag
                 self.numberOfLines.append(line)
@@ -86,7 +86,7 @@ final class LineCarouselControl: UIControl {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        print("An error occured")
+        Log.print("An error occured")
     }
 
     // MARK: methods

--- a/SayTheirNames/Source/Controller/Home/CollectionViewDataSource/PersonCollectionViewDataSource.swift
+++ b/SayTheirNames/Source/Controller/Home/CollectionViewDataSource/PersonCollectionViewDataSource.swift
@@ -82,7 +82,7 @@ final class PersonCollectionViewDataSourceHelper {
     func appendPeople(_ people: [Person]) {
         var snapshot = dataSource.snapshot()
         guard snapshot.sectionIdentifiers.contains(.main) else {
-            print("Main section doesn't exist!!")
+            Log.print("Main section doesn't exist!!")
             return
         }
         snapshot.appendItems(people.map({ SectionData.person($0) }), toSection: .main)

--- a/SayTheirNames/Source/Controller/Home/Person/PersonController.swift
+++ b/SayTheirNames/Source/Controller/Home/Person/PersonController.swift
@@ -307,7 +307,7 @@ extension PersonController: PersonCollectionViewCellDelegate {
     }
     
     func didTapMediaItem(_ media: Media) {
-        print("Did tap media")
+        Log.print("Did tap media")
     }
 }
 

--- a/SayTheirNames/Source/Controller/Home/Person/Views/PersonNewsCollectionViewCell.swift
+++ b/SayTheirNames/Source/Controller/Home/Person/Views/PersonNewsCollectionViewCell.swift
@@ -68,7 +68,7 @@ class PersonNewsCollectionViewCell: UICollectionViewCell {
                             self?.loadingIndicator.stopAnimating()
                         }
                     case .failure(let error):
-                        print(url)
+                        Log.print(url)
                         DispatchQueue.main.async {
                             self?.loadingIndicator.stopAnimating()
                         }

--- a/SayTheirNames/Source/Controller/Launch/LaunchScreen.swift
+++ b/SayTheirNames/Source/Controller/Launch/LaunchScreen.swift
@@ -40,7 +40,7 @@ final class LaunchScreen: UIView {
     static func createFromNib() -> LaunchScreen? {
         let bundle = Bundle(for: LaunchScreen.self)
         guard let view = bundle.loadNibNamed("LaunchScreen", owner: nil)?.first as? LaunchScreen else {
-            print("Can't load `LaunchScreen` from nib")
+            Log.print("Can't load `LaunchScreen` from nib")
             return nil
         }
         view.backgroundColor = UIColor(asset: STNAsset.Color.black)

--- a/SayTheirNames/Source/Log/Log.swift
+++ b/SayTheirNames/Source/Log/Log.swift
@@ -87,8 +87,3 @@ public enum Log {
         return result
     }
 }
-
-// MARK: - Loggable
-@objc protocol Loggable {
-    func desc() -> String
-}

--- a/SayTheirNames/Source/Utils/Extentions/UIFont+STN.swift
+++ b/SayTheirNames/Source/Utils/Extentions/UIFont+STN.swift
@@ -41,7 +41,7 @@ extension UIFont {
         }
         else {
             uiFont = UIFont.preferredFont(forTextStyle: textStyle)
-            print("Got invalid font \(fontName) with style \(textStyle). Using \(uiFont)")
+            Log.print("Got invalid font \(fontName) with style \(textStyle). Using \(uiFont)")
         }
         
         return uiFont
@@ -59,7 +59,7 @@ extension UIFont {
         }
         else {
             uiFont = UIFont.systemFont(ofSize: size)
-            print("Got invalid font \(fontName) with size \(size). Using \(uiFont)")
+            Log.print("Got invalid font \(fontName) with size \(size). Using \(uiFont)")
         }
         
         return uiFont


### PR DESCRIPTION
Change all calls from `print` to `Log.print`. 
 - Logging will stop once the `DEBUG` preprocessor macro is set to 0.