### PR TITLE
[FIX] Disable ko & pt-BR locales

### DIFF
--- a/SayTheirNames.xcodeproj/project.pbxproj
+++ b/SayTheirNames.xcodeproj/project.pbxproj
@@ -251,7 +251,6 @@
 		7CAD53E7248A326F001CFF08 /* PetitionsNetworkRequestorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetitionsNetworkRequestorTests.swift; sourceTree = "<group>"; };
 		7CAD53E9248A32FC001CFF08 /* PeopleNetworkRequestorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleNetworkRequestorTests.swift; sourceTree = "<group>"; };
 		7CE75F352489820700168DDA /* PetitionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetitionsView.swift; sourceTree = "<group>"; };
-		8381E475248D7CEC00EA1E43 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		83E9CACF2484A504001D173A /* LaunchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreen.swift; sourceTree = "<group>"; };
 		83E9CAD12484A514001D173A /* LaunchScreen.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		83E9CAD32484A5DC001D173A /* UIViewController+TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+TabBar.swift"; sourceTree = "<group>"; };
@@ -354,7 +353,6 @@
 		C0594BF9248754A200260BAD /* UICollectionView++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView++.swift"; sourceTree = "<group>"; };
 		D107CEC59C11537D09D9DB2E /* Pods-Say Their Names.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Say Their Names.release.xcconfig"; path = "Target Support Files/Pods-Say Their Names/Pods-Say Their Names.release.xcconfig"; sourceTree = "<group>"; };
 		D42BC32C248E290E006A7F4B /* assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = assets.swift; sourceTree = "<group>"; };
-		D4BA10D0248A8F7300E29A3F /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D639F16885E8E79F7E336CC2 /* Pods-Say Their Names.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Say Their Names.debug.xcconfig"; path = "Target Support Files/Pods-Say Their Names/Pods-Say Their Names.debug.xcconfig"; sourceTree = "<group>"; };
 		D757CF07248F3A9C008874B4 /* DonationTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationTypes.swift; sourceTree = "<group>"; };
 		D787FC9A248A71A3001FC6FF /* ImageWithBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageWithBlurView.swift; sourceTree = "<group>"; };
@@ -1144,9 +1142,7 @@
 				en,
 				Base,
 				fr,
-				"pt-BR",
 				ar,
-				ko,
 				ru,
 				nl,
 			);
@@ -1520,9 +1516,7 @@
 			children = (
 				9E24499C2485E98C00B149DF /* Base */,
 				8E94BA59248A0A4100242FBA /* fr */,
-				D4BA10D0248A8F7300E29A3F /* pt-BR */,
 				5E531926248D191F00021996 /* ar */,
-				8381E475248D7CEC00EA1E43 /* ko */,
 				B35AEE222492DDCD005F2AAF /* ru */,
 				1846CA492493E9BA00792086 /* nl */,
 			);

--- a/SayTheirNames/Resources/Base.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/Base.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: en, English 
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:00 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:03 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/ar.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/ar.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: ar, Arabic
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:02 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:05 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/en.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: en, English 
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:00 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:03 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/fr.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: fr, French
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:03 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:06 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/ko.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/ko.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: ko, Korean
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:04 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:06 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/nl.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/nl.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: nl, Dutch; Flemish
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:04 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:06 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/pt-BR.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/pt-BR.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: pt-BR, Brazilian Portuguese
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:02 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:05 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */

--- a/SayTheirNames/Resources/ru.lproj/Localizable.strings
+++ b/SayTheirNames/Resources/ru.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Release: Working copy
  * Locale: ru, Russian
  * Exported by: Say Their Names
- * Exported at: Fri, 12 Jun 2020 21:09:01 +0200
+ * Exported at: Fri, 12 Jun 2020 22:42:05 +0200
  */
 
 /* loco:5ee29770f904c5151c1a2061 */
@@ -109,11 +109,11 @@
 "get_involved.developer.title" = "Я разработчик - как я могу помочь?";
 
 /* loco:5ee29770f904c5151c1a2083 */
-"get_involved.developer.button" = "Наш GitHub";
+"get_involved.developer.button" = "Наш гитхаб";
 
 /* loco:5ee29770f904c5151c1a2085
  * Get Involved - Twitter */
-"get_involved.twitter.title" = "Подписаться на Twitter";
+"get_involved.twitter.title" = "Подписаться в Твиттере";
 
 /* loco:5ee29770f904c5151c1a2086 */
 "get_involved.twitter.button" = "Подписаться";

--- a/SayTheirNames/Source/Dependency/Networking/Environment.swift
+++ b/SayTheirNames/Source/Dependency/Networking/Environment.swift
@@ -25,14 +25,6 @@ import Foundation
 
 enum Environment {
     static let serverURLString: String = {
-        #if DEV
-            return "https://saytheirnames.dev"
-        #elseif QA
-            return "https://saytheirnames.qa"
-        #elseif LOCAL
-            return "https://localhost"
-        #else
-            return "https://saytheirnames.dev" // switch to PROD
-        #endif
+        "https://saytheirnames.dev"
     }()
 }


### PR DESCRIPTION
Disabling korean and pt-BR localizations - they're both translated less than 50%. Can easily re-enable them again later when they're complete. 

Created cards on trello to add missing translations to these languages.