### PR TITLE
[UI] Add trailing padding for about section

### DIFF
--- a/SayTheirNames/Source/Controller/More/MoreView.swift
+++ b/SayTheirNames/Source/Controller/More/MoreView.swift
@@ -172,7 +172,7 @@ final class MoreView: UIView {
         
         NSLayoutConstraint.activate([
             moreCard.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: padding),
-            moreCard.trailingAnchor.constraint(equalTo: trailingAnchor, constant: padding),
+            moreCard.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -padding),
             moreCard.leadingAnchor.constraint(equalTo: leadingAnchor, constant: padding),
             moreCard.heightAnchor.constraint(equalTo: moreCard.widthAnchor, multiplier: Theme.Screens.About.card.multiplier)
         ])


### PR DESCRIPTION
About section was overflowing, adding negative padding to trailingAnchor.