### PR TITLE
[FIX] Fix HeroTextCell showing person details when selected

### DIFF
--- a/SayTheirNames/Source/Controller/Home/HomeController.swift
+++ b/SayTheirNames/Source/Controller/Home/HomeController.swift
@@ -187,7 +187,7 @@ extension HomeController: UICollectionViewDelegateFlowLayout {
             // nothing for now
         } else if collectionView === peopleCollectionView {
             // People CollectionView
-            
+            guard peopleDataSourceHelper.section(at: indexPath.section) == .main else { return }
             guard let selectedPerson = peopleDataSourceHelper.person(at: indexPath.item) else { return }
             self.showPersonDetails(withPerson: selectedPerson)
         }


### PR DESCRIPTION
Fixes #227.

Added a `guard` statement to verify the user clicked on a cell that was located in the main section.