### PR TITLE
[FIX] Making sure names fit on home

### DIFF
--- a/SayTheirNames/Source/Controller/Home/HomeView.swift
+++ b/SayTheirNames/Source/Controller/Home/HomeView.swift
@@ -84,16 +84,33 @@ final class HomeView: UIView {
             
             case .main:
                 
+                let sizeCategory = layoutEnviroment.traitCollection.preferredContentSizeCategory
+                let heightMultiplier: CGFloat
+                if sizeCategory >= .accessibilityExtraLarge {
+                    heightMultiplier = 1.5
+                }
+                else if sizeCategory >= .accessibilityMedium {
+                    heightMultiplier = 1.3
+                }
+                else if sizeCategory >= .extraExtraLarge {
+                    heightMultiplier = 1.15
+                }
+                else {
+                    heightMultiplier = 1.0
+                }
+                
+                let height: CGFloat = Theme.Screens.Home.CellSize.peopleHeight * CGFloat(heightMultiplier)
+
                 let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
                 let layoutItem = NSCollectionLayoutItem(layoutSize: itemSize)
 
-                let height = Theme.Screens.Home.CellSize.peopleHeight
                 let columns = deviceWidth == .compact ? Theme.Screens.Home.Columns.compactScreenWidth : Theme.Screens.Home.Columns.wideScreenWidth
                 let layoutGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(height))
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: layoutGroupSize, subitem: layoutItem, count: columns)
                 group.interItemSpacing = .fixed(Self.horizontalPaddingBetween)
                 
                 let mainSection = NSCollectionLayoutSection(group: group)
+                mainSection.interGroupSpacing = Self.horizontalPaddingBetween * 2
                 section = mainSection
                 
             case .header:

--- a/SayTheirNames/Source/Utils/Theme/Theme.swift
+++ b/SayTheirNames/Source/Utils/Theme/Theme.swift
@@ -83,7 +83,7 @@ enum Theme {
             enum CellSize {
                 static let location: CGSize = CGSize(width: 103, height: 36)
                 static let headerHeight: CGFloat = 150
-                static let peopleHeight: CGFloat = 300
+                static let peopleHeight: CGFloat = 280
                 static let carouselCardHeight: CGFloat = 170
             }
             enum NavigationBar {

--- a/SayTheirNames/Source/View/Home/Person/PersonCell.swift
+++ b/SayTheirNames/Source/View/Home/Person/PersonCell.swift
@@ -42,7 +42,10 @@ final class PersonCell: UICollectionViewCell {
         let lbl = UILabel()
         lbl.textColor = UIColor(asset: STNAsset.Color.primaryLabel)
         lbl.lineBreakMode = .byTruncatingTail
+        lbl.numberOfLines = 2
         lbl.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        lbl.setContentCompressionResistancePriority(.required - 1, for: .vertical)
+        lbl.setContentHuggingPriority(.required, for: .vertical)
         lbl.translatesAutoresizingMaskIntoConstraints = false
         lbl.isAccessibilityElement = true
         lbl.accessibilityLabel = lbl.text
@@ -55,6 +58,8 @@ final class PersonCell: UICollectionViewCell {
         lbl.lineBreakMode = .byTruncatingTail
         lbl.isAccessibilityElement = true
         lbl.translatesAutoresizingMaskIntoConstraints = false
+        lbl.setContentHuggingPriority(.required, for: .vertical)
+        lbl.setContentCompressionResistancePriority(.required, for: .vertical)
         return lbl
     }()
     
@@ -77,6 +82,7 @@ final class PersonCell: UICollectionViewCell {
         stack.spacing = 10
         stack.distribution = .fill
         stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.setContentHuggingPriority(.required, for: .vertical)
         return stack
     }()
     
@@ -112,23 +118,33 @@ final class PersonCell: UICollectionViewCell {
 
         containerStack.addArrangedSubview(profileImageView)
         containerStack.addArrangedSubview(labelsAndButtonContainer)
-        NSLayoutConstraint.activate([
+        
+        var constraints: [NSLayoutConstraint] = [
             nameLabel.topAnchor.constraint(equalTo: labelsAndButtonContainer.topAnchor),
             nameLabel.leadingAnchor.constraint(equalTo: labelsAndButtonContainer.leadingAnchor),
-            nameLabel.trailingAnchor.constraint(equalTo: bookmarkButton.leadingAnchor, constant: 4),
 
             dateOfIncidentLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor),
             dateOfIncidentLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
-            dateOfIncidentLabel.bottomAnchor.constraint(equalTo: labelsAndButtonContainer.bottomAnchor, constant: -20),
+            dateOfIncidentLabel.bottomAnchor.constraint(lessThanOrEqualTo: labelsAndButtonContainer.bottomAnchor),
             dateOfIncidentLabel.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor),
 
-            bookmarkButton.topAnchor.constraint(equalTo: nameLabel.topAnchor),
-            bookmarkButton.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor),
-
-            profileImageView.heightAnchor.constraint(equalTo: containerStack.heightAnchor, multiplier: 0.8),
-
-            labelsAndButtonContainer.heightAnchor.constraint(greaterThanOrEqualTo: containerStack.heightAnchor, multiplier: 0.2, constant: -20)
-        ])
+            profileImageView.heightAnchor.constraint(equalToConstant: Theme.Screens.Home.CellSize.peopleHeight * 0.85),
+        ]
+        
+        if FeatureFlags.bookmarksEnabled {
+            constraints.append(contentsOf: [
+                nameLabel.trailingAnchor.constraint(equalTo: bookmarkButton.leadingAnchor, constant: 4),
+                bookmarkButton.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor),
+                bookmarkButton.topAnchor.constraint(equalTo: nameLabel.topAnchor),
+            ])
+        }
+        else {
+            constraints.append(contentsOf: [
+                nameLabel.trailingAnchor.constraint(equalTo: labelsAndButtonContainer.trailingAnchor)
+            ])
+        }
+        
+        NSLayoutConstraint.activate(constraints)
         
         containerStack.addArrangedSubview(profileImageView)
         containerStack.addArrangedSubview(labelsAndButtonContainer)


### PR DESCRIPTION
Resolves #250 

The default text size looks the same, but on larger content sizes two lines are now allowed.

| Before | After |
|:------:|:------:|
|<img width="517" alt="Screenshot 2020-08-17 at 16 45 49" src="https://user-images.githubusercontent.com/11408899/90520952-447c4800-e16a-11ea-8aaf-15bc32f193d1.png">|<img width="517" alt="Screenshot 2020-08-18 at 15 48 03" src="https://user-images.githubusercontent.com/11408899/90520983-4b0abf80-e16a-11ea-86de-c732dbbb7240.png">|
