### PR TITLE
[CHORE] Remove Korean from localise.biz

### DIFF
--- a/scripts/download_loco.sh
+++ b/scripts/download_loco.sh
@@ -16,7 +16,7 @@ function destination_path {
 # created by @hybridcattt
 KEY="L1dFmJVo4QFj08yySbMQWMo-RIvWcnZ5"
 
-LANGS=( "en" "ru" "pt-BR" "ar" "fr" "ko" "nl" "es" "de" "he")
+LANGS=( "en" "ru" "pt-BR" "ar" "fr" "nl" "es" "de" "he")
 
 echo "\nDownlading Base ...."
 curl -u $KEY: $(download_url "en") > $(destination_path "Base")


### PR DESCRIPTION
We reached a limit of 10 languages. I think we can remove Korean because it's not finished and unused, and there's no one that can work on it. Clarification: I already removed it from localise.biz, this is just removing it from the script. 
I'm leaving the .strings files in the repo in case we want to reintroduce the language later - they could be reuploaded to localise.biz.